### PR TITLE
add file-like object support for load_userdict

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -165,9 +165,11 @@ def cut(sentence,cut_all=False):
 				if x!="":
 					yield x
 
-def load_userdict(f_name):
+def load_userdict(f):
 	global trie,total,FREQ
-	content = open(f_name,'rb').read().decode('utf-8')
+	if isinstance(f, (str, unicode)):
+		f = open(f, 'rb')
+	content = f.read().decode('utf-8')
 	for line in content.split("\n"):
 		if line.rstrip()=='': continue
 		word,freq = line.split(" ")


### PR DESCRIPTION
我需要用数据库管理自定义词库, 折衷的方法是写入StringIO然后调用load_userdict.
简单的修改了一下, 使得类似文件的对象可以被支持. 类似的做法在许多模块里都有, 比较常见, 也不会破坏兼容性.
