### PR TITLE
新增自訂 cache_file 產生的目錄位置，可支援 jieba 運行在 Read-Only File System，如： Embedded Linux、Google App Engine 和 Heroku 等

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -23,6 +23,7 @@ total = 0
 user_word_tag_tab = {}
 initialized = False
 pool = None
+tmp_dir = None
 
 _curpath = os.path.normpath(
     os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -61,7 +62,7 @@ def gen_pfdict(f_name):
 
 
 def initialize(dictionary=None):
-    global FREQ, total, initialized, DICTIONARY, DICT_LOCK
+    global FREQ, total, initialized, DICTIONARY, DICT_LOCK, tmp_dir
     if not dictionary:
         dictionary = DICTIONARY
     with DICT_LOCK:
@@ -73,9 +74,9 @@ def initialize(dictionary=None):
         t1 = time.time()
         # default dictionary
         if abs_path == os.path.join(_curpath, "dict.txt"):
-            cache_file = os.path.join(tempfile.gettempdir(), "jieba.cache")
+            cache_file = os.path.join(tmp_dir if tmp_dir else tempfile.gettempdir(),"jieba.cache")
         else:  # custom dictionary
-            cache_file = os.path.join(tempfile.gettempdir(), "jieba.u%s.cache" % md5(
+            cache_file = os.path.join(tmp_dir if tmp_dir else tempfile.gettempdir(),"jieba.u%s.cache" % md5(
                 abs_path.encode('utf-8', 'replace')).hexdigest())
 
         load_from_cache_fail = True


### PR DESCRIPTION
假設服務跑在 Read-Only File System 中，不能使用 tempfile.gettempdir() ，如果能夠指定 tmp_dir ，就能夠把 cache 產生後擺上使用。

因此，在維持最小的系統架構更改的設計下，我做了幾行的變動，提供指定 cache 的產生位置及讀取位置。

若要使用，只需：

import jieba
jieba.tmp_dir = os.path.dirname(os.path.abspath(__file__)) + '/tmp'
