### PR TITLE
Fix divided by zero issue in case of words are not found in dict.

### DIFF
--- a/jieba/analyse/textrank.py
+++ b/jieba/analyse/textrank.py
@@ -21,7 +21,7 @@ class UndirectWeightedGraph:
         ws = collections.defaultdict(float)
         outSum = collections.defaultdict(float)
 
-        wsdef = 1.0 / len(self.graph)
+        wsdef = 1.0 / (len(self.graph) or 1.0)
         for n, out in self.graph.items():
             ws[n] = wsdef
             outSum[n] = sum((e[2] for e in out), 0.0)


### PR DESCRIPTION
碰巧在处理大量文本时抓到这个bug

错误重现方法：

``` python
import jieba.analyse.textrank as rk
rk('阿修罗闪空')
```

在输入文本较短而没有找到任何录入词典的生词时
会出现divided by zero错误
