### PR TITLE
修复 posseg 中 pair 类 repr 返回值 (jieba3k)

### DIFF
--- a/jieba/analyse/textrank.py
+++ b/jieba/analyse/textrank.py
@@ -21,7 +21,7 @@ class UndirectWeightedGraph:
         ws = collections.defaultdict(float)
         outSum = collections.defaultdict(float)
 
-        wsdef = 1.0 / len(self.graph)
+        wsdef = 1.0 / (len(self.graph) or 1.0)
         for n, out in self.graph.items():
             ws[n] = wsdef
             outSum[n] = sum((e[2] for e in out), 0.0)

--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -81,7 +81,7 @@ class pair(object):
         return self.__str__()
 
     def __str__(self):
-        return self.__unicode__().encode(default_encoding)
+        return self.__unicode__()
 
     def encode(self,arg):
         return self.__unicode__().encode(arg)


### PR DESCRIPTION
- #205
- posseg 中 `pair.__repr__` 返回值类型应为 str，不是 bytes
