### PR TITLE
在 FREQ 中直接储存频数  (Python 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,12 +330,12 @@ https://github.com/fxsjy/jieba/raw/master/extra_dict/dict.txt.big
 
 结巴分词 C++ 版本
 ----------------
-作者：Aszxqw
+作者：yanyiwu
 地址：https://github.com/aszxqw/cppjieba
 
 结巴分词 Node.js 版本
 ----------------
-作者：Aszxqw
+作者：yanyiwu
 地址：https://github.com/aszxqw/nodejieba
 
 结巴分词 Erlang 版本
@@ -347,6 +347,11 @@ https://github.com/fxsjy/jieba/raw/master/extra_dict/dict.txt.big
 ----------------
 作者：qinwf
 地址：https://github.com/qinwf/jiebaR
+
+结巴分词 iOS 版本
+----------------
+作者：yanyiwu
+地址：https://github.com/aszxqw/iosjieba
 
 系统集成
 ========

--- a/jieba/finalseg/__init__.py
+++ b/jieba/finalseg/__init__.py
@@ -40,8 +40,9 @@ def load_model():
 if sys.platform.startswith("java"):
     start_P, trans_P, emit_P = load_model()
 else:
-    from . import prob_start,prob_trans,prob_emit
-    start_P, trans_P, emit_P = prob_start.P, prob_trans.P, prob_emit.P
+    from .prob_start import P as start_P
+    from .prob_trans import P as trans_P
+    from .prob_emit  import P as emit_P
 
 def viterbi(obs, states, start_p, trans_p, emit_p):
     V = [{}] #tabular
@@ -49,7 +50,7 @@ def viterbi(obs, states, start_p, trans_p, emit_p):
     for y in states: #init
         V[0][y] = start_p[y] + emit_p[y].get(obs[0],MIN_FLOAT)
         path[y] = [y]
-    for t in range(1,len(obs)):
+    for t in range(1, len(obs)):
         V.append({})
         newpath = {}
         for y in states:
@@ -67,7 +68,7 @@ def viterbi(obs, states, start_p, trans_p, emit_p):
 def __cut(sentence):
     global emit_P
     prob, pos_list =  viterbi(sentence, ('B','M','E','S'), start_P, trans_P, emit_P)
-    begin, next = 0,0
+    begin, nexti = 0, 0
     #print pos_list, sentence
     for i,char in enumerate(sentence):
         pos = pos_list[i]
@@ -75,12 +76,12 @@ def __cut(sentence):
             begin = i
         elif pos == 'E':
             yield sentence[begin:i+1]
-            next = i+1
+            nexti = i+1
         elif pos == 'S':
             yield char
-            next = i+1
-    if next < len(sentence):
-        yield sentence[next:]
+            nexti = i+1
+    if nexti < len(sentence):
+        yield sentence[nexti:]
 
 def cut(sentence):
     if not isinstance(sentence, str):

--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -54,8 +54,11 @@ def load_model(f_name, isJython=True):
 if sys.platform.startswith("java"):
     char_state_tab_P, start_P, trans_P, emit_P, word_tag_tab = load_model(jieba.get_abs_path_dict())
 else:
-    from . import char_state_tab, prob_start, prob_trans, prob_emit
-    char_state_tab_P, start_P, trans_P, emit_P = char_state_tab.P, prob_start.P, prob_trans.P, prob_emit.P
+    from .char_state_tab import P as char_state_tab_P
+    from .prob_start import P as start_P
+    from .prob_trans import P as trans_P
+    from .prob_emit  import P as emit_P
+
     word_tag_tab = load_model(jieba.get_abs_path_dict(), isJython=False)
 
 def makesure_userdict_loaded(fn):
@@ -164,16 +167,14 @@ def __cut_DAG(sentence):
             if buf:
                 if len(buf) == 1:
                     yield pair(buf, word_tag_tab.get(buf, 'x'))
-                    buf = ''
+                elif buf not in jieba.FREQ:
+                    recognized = __cut_detail(buf)
+                    for t in recognized:
+                        yield t
                 else:
-                    if (buf not in jieba.FREQ):
-                        recognized = __cut_detail(buf)
-                        for t in recognized:
-                            yield t
-                    else:
-                        for elem in buf:
-                            yield pair(elem, word_tag_tab.get(elem, 'x'))
-                    buf = ''
+                    for elem in buf:
+                        yield pair(elem, word_tag_tab.get(elem, 'x'))
+                buf = ''
             yield pair(l_word, word_tag_tab.get(l_word, 'x'))
         x = y
 
@@ -228,7 +229,7 @@ def __lcut_internal_no_hmm(sentence):
 
 @makesure_userdict_loaded
 def cut(sentence, HMM=True):
-    if (not hasattr(jieba, 'pool')) or (jieba.pool is None):
+    if jieba.pool is None:
         for w in __cut_internal(sentence, HMM=HMM):
             yield w
     else:


### PR DESCRIPTION
同 #231。

## 讨论：Python 3 支持问题

这样来来回回更新很麻烦诶，有没有可能把 jieba 和 jieba3k 合并？成熟的做法有加一个 `_compat` 模块定义全局映射，解决 str/unicode、range/xrange 等问题。不过像 prob_emit 等数据模块可能需要 `from __future__ import absolute_import, unicode_literals`，因为 `u'字符串'` 的写法在 Py 3.3+ 才支持，相对模块导入的写法 Python 2 和 3 不同 (PEP 328)。
`with_statement` 的导入应该可以移除了，2.6 以下的能运行这个库吗？

> feature | optional in | mandatory in | effect
> ------------- | ------------- | ------------- | -------------
> absolute_import | 2.5.0a1 | 3.0 | PEP 328: Imports: Multi-Line and Absolute/Relative
> with_statement | 2.5.0a1 | 2.6 | PEP 343: The “with” Statement
> print_function | 2.6.0a2 | 3.0 | PEP 3105: Make print a function
> unicode_literals | 2.6.0a2 | 3.0 | PEP 3112: Bytes literals in Python 3000
