### PR TITLE
直接将前缀储存在词频字典里

### DIFF
--- a/test/test_cut_for_search.py
+++ b/test/test_cut_for_search.py
@@ -1,4 +1,5 @@
 #encoding=utf-8
+from __future__ import print_function
 import sys
 sys.path.append("../")
 import jieba

--- a/test/test_cutall.py
+++ b/test/test_cutall.py
@@ -1,4 +1,5 @@
 #encoding=utf-8
+from __future__ import print_function
 import sys
 sys.path.append("../")
 import jieba

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,4 +1,4 @@
-import sys,time
+import time
 import sys
 sys.path.append("../")
 import jieba

--- a/test/test_pos_no_hmm.py
+++ b/test/test_pos_no_hmm.py
@@ -1,4 +1,5 @@
 #encoding=utf-8
+from __future__ import print_function
 import sys
 sys.path.append("../")
 import jieba.posseg as pseg

--- a/test/test_userdict.py
+++ b/test/test_userdict.py
@@ -1,4 +1,5 @@
 #encoding=utf-8
+from __future__ import print_function
 import sys
 sys.path.append("../")
 import jieba


### PR DESCRIPTION
* 取消 `pfdict`，只用 `FREQ` 储存，前缀的词频为 0。参考 #160 的思想

这能提高一点 `get_DAG` 的效率，大概补回一半每次计算频率的性能损失。