### PR TITLE
exlucde word fragments from FREQ in posseg.cut

### DIFF
--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -189,7 +189,7 @@ def __cut_DAG(sentence):
             if buf:
                 if len(buf) == 1:
                     yield pair(buf, word_tag_tab.get(buf, 'x'))
-                elif buf not in jieba.FREQ:
+                elif not jieba.FREQ.get(buf):
                     recognized = __cut_detail(buf)
                     for t in recognized:
                         yield t
@@ -203,7 +203,7 @@ def __cut_DAG(sentence):
     if buf:
         if len(buf) == 1:
             yield pair(buf, word_tag_tab.get(buf, 'x'))
-        elif (buf not in jieba.FREQ):
+        elif not jieba.FREQ.get(buf):
             recognized = __cut_detail(buf)
             for t in recognized:
                 yield t


### PR DESCRIPTION
感觉应该是在从Trie转换到Prefix Map的时候遗漏了对posseg.cut的更新，导致有的切分结果出现不一致，比如：

```
>>> from jieba import posseg
>>> list(posseg.cut("伊藤洋华堂总府店"))
```

结果是：

```
[伊/ns, 藤/nr, 洋华堂/n, 总府/n, 店/n]
```

转换之前的结果是：
```
[伊藤/nr, 洋华堂/n, 总府/n, 店/n]
```