### PR TITLE
修复 cut_for_search；改善 pair 对象

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ https://github.com/fxsjy/jieba/blob/master/test/extract_tags.py
 ```pycon
 >>> import jieba.posseg as pseg
 >>> words = pseg.cut("我爱北京天安门")
->>> for w in words:
-...    print('%s %s' % (w.word, w.flag))
+>>> for word, flag in words:
+...    print('%s %s' % (word, flag))
 ...
 我 r
 爱 v

--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -310,12 +310,12 @@ class Tokenizer(object):
             if len(w) > 2:
                 for i in xrange(len(w) - 1):
                     gram2 = w[i:i + 2]
-                    if FREQ.get(gram2):
+                    if self.FREQ.get(gram2):
                         yield gram2
             if len(w) > 3:
                 for i in xrange(len(w) - 2):
                     gram3 = w[i:i + 3]
-                    if FREQ.get(gram3):
+                    if self.FREQ.get(gram3):
                         yield gram3
             yield w
 

--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -70,13 +70,16 @@ class pair(object):
         return '%s/%s' % (self.word, self.flag)
 
     def __repr__(self):
-        return self.__str__()
+        return 'pair(%r, %r)' % (self.word, self.flag)
 
     def __str__(self):
         if PY2:
             return self.__unicode__().encode(default_encoding)
         else:
             return self.__unicode__()
+
+    def __iter__(self):
+        return iter((self.word, self.flag))
 
     def encode(self, arg):
         return self.__unicode__().encode(arg)

--- a/test/demo.py
+++ b/test/demo.py
@@ -62,8 +62,8 @@ print('4. 词性标注')
 print('-'*40)
 
 words = jieba.posseg.cut("我爱北京天安门")
-for w in words:
-    print('%s %s' % (w.word, w.flag))
+for word, flag in words:
+    print('%s %s' % (word, flag))
 
 print('='*40)
 print('6. Tokenize: 返回词语在原文的起止位置')

--- a/test/test_pos.py
+++ b/test/test_pos.py
@@ -6,8 +6,8 @@ import jieba.posseg as pseg
 
 def cuttest(test_sent):
     result = pseg.cut(test_sent)
-    for w in result:
-        print(w.word, "/", w.flag, ", ", end=' ')
+    for word, flag in result:
+        print(word, "/", flag, ", ", end=' ')
     print("")
 
 

--- a/test/test_pos_no_hmm.py
+++ b/test/test_pos_no_hmm.py
@@ -5,9 +5,9 @@ sys.path.append("../")
 import jieba.posseg as pseg
 
 def cuttest(test_sent):
-    result = pseg.cut(test_sent,HMM=False)
-    for w in result:
-        print(w.word, "/", w.flag, ", ", end=' ')  
+    result = pseg.cut(test_sent, HMM=False)
+    for word, flag in result:
+        print(word, "/", flag, ", ", end=' ')
     print("")
 
 


### PR DESCRIPTION
* cut_for_search 中修复 self.FREQ.get
* jieba.posseg.pair 对象
  * `__repr__` 改为标准格式
  * 加入 `__iter__`，可使用 `for word, flag in posseg.cut(s):` 这样的语法。