### PR TITLE
add a withFlag param to extract_tags

### DIFF
--- a/jieba/analyse/tfidf.py
+++ b/jieba/analyse/tfidf.py
@@ -72,7 +72,7 @@ class TFIDF(KeywordExtractor):
         self.idf_loader.set_new_path(new_abs_path)
         self.idf_freq, self.median_idf = self.idf_loader.get_idf()
 
-    def extract_tags(self, sentence, topK=20, withWeight=False, allowPOS=()):
+    def extract_tags(self, sentence, topK=20, withWeight=False, allowPOS=(), withFlag=False):
         """
         Extract keywords from sentence using TF-IDF algorithm.
         Parameter:
@@ -81,6 +81,9 @@ class TFIDF(KeywordExtractor):
                           if False, return a list of words.
             - allowPOS: the allowed POS list eg. ['ns', 'n', 'vn', 'v','nr'].
                         if the POS of w is not in this list,it will be filtered.
+            - withFlag: only work with allowPOS is not empty.
+                        if True, return a list of pair(word, weight) like posseg.cut
+                        if False, return a list of words
         """
         if allowPOS:
             allowPOS = frozenset(allowPOS)
@@ -92,14 +95,16 @@ class TFIDF(KeywordExtractor):
             if allowPOS:
                 if w.flag not in allowPOS:
                     continue
-                else:
+                elif not withFlag:
                     w = w.word
-            if len(w.strip()) < 2 or w.lower() in self.stop_words:
+            wc = w.word if allowPOS and withFlag else w
+            if len(wc.strip()) < 2 or wc.lower() in self.stop_words:
                 continue
             freq[w] = freq.get(w, 0.0) + 1.0
         total = sum(freq.values())
         for k in freq:
-            freq[k] *= self.idf_freq.get(k, self.median_idf) / total
+            kw = k.word if allowPOS and withFlag else k
+            freq[k] *= self.idf_freq.get(kw, self.median_idf) / total
 
         if withWeight:
             tags = sorted(freq.items(), key=itemgetter(1), reverse=True)

--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -81,6 +81,9 @@ class pair(object):
     def __iter__(self):
         return iter((self.word, self.flag))
 
+    def __lt__(self, other):
+        return self.word < other.word
+
     def encode(self, arg):
         return self.__unicode__().encode(arg)
 

--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -84,6 +84,12 @@ class pair(object):
     def __lt__(self, other):
         return self.word < other.word
 
+    def __eq__(self, other):
+        return isinstance(other, pair) and self.word == other.word and self.flag == other.flag
+
+    def __hash__(self):
+        return hash(self.word)
+
     def encode(self, arg):
         return self.__unicode__().encode(arg)
 


### PR DESCRIPTION
觉得extract_tags有allowPOS参数的时候返回没有词性信息有点麻烦，所以加了一个参数withFlag，为True时像posseg.cut那样返回一个list of pair。（当然默认为False，不会影响到以前的代码）

测试结果如下。

```python
>>> from jieba.analyse import extract_tags as et

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造'))
['日本京都大学', '计算所', '小明', '深造', '硕士', '中国科学院', '毕业']

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造', withWeight=True))
[('日本京都大学', 1.8867900673428573), ('计算所', 1.6719218678), ('小明', 1.589726989957143), ('深造', 1.2983561852285714), ('硕士', 1.2671771043685713), ('中国科学院', 1.098295936602857), ('毕业', 0.8902356233414286)]

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造', allowPOS=['n']))
['计算所', '硕士', '毕业']

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造', allowPOS=['n'], withWeight=True))
[('计算所', 3.901151024866667), ('硕士', 2.95674657686), ('毕业', 2.077216454463333)]

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造', allowPOS=['n'], withFlag=True))
[pair('计算所', 'n'), pair('硕士', 'n'), pair('毕业', 'n')]

>>> list(et('小明硕士毕业于中国科学院计算所，后在日本京都大学深造', allowPOS=['n'], withFlag=True, withWeight=True))
[(pair('计算所', 'n'), 3.901151024866667), (pair('硕士', 'n'), 2.95674657686), (pair('毕业', 'n'), 2.077216454463333)]
```