### PR TITLE
Add LICENSE to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft README.md
 graft Changelog
+graft LICENSE


### PR DESCRIPTION
Hey-lo,

I'm building a version of `jieba` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution. This pull should add the license to the next source bundle that gets released.