### PR TITLE
typos

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -161,7 +161,7 @@ class Tokenizer(object):
             self.initialized = True
             default_logger.debug(
                 "Loading model cost %.3f seconds." % (time.time() - t1))
-            default_logger.debug("Prefix dict has been built succesfully.")
+            default_logger.debug("Prefix dict has been built successfully.")
 
     def check_initialized(self):
         if not self.initialized:


### PR DESCRIPTION
"succesfully" should be "successfully" (missing "s")