### PR TITLE
fix exception "Not a directory" when using analyse module

### DIFF
--- a/jieba/analyse/tfidf.py
+++ b/jieba/analyse/tfidf.py
@@ -4,6 +4,7 @@ import os
 import jieba
 import jieba.posseg
 from operator import itemgetter
+from ..compat import get_module_res
 
 _get_module_path = lambda path: os.path.normpath(os.path.join(os.getcwd(),
                                                  os.path.dirname(__file__), path))
@@ -44,7 +45,7 @@ class IDFLoader(object):
     def set_new_path(self, new_idf_path):
         if self.path != new_idf_path:
             self.path = new_idf_path
-            content = open(new_idf_path, 'rb').read().decode('utf-8')
+            content = get_module_res(new_idf_path).read().decode('utf-8')
             self.idf_freq = {}
             for line in content.splitlines():
                 word, freq = line.strip().split(' ')

--- a/jieba/analyse/tfidf.py
+++ b/jieba/analyse/tfidf.py
@@ -4,13 +4,11 @@ import os
 import jieba
 import jieba.posseg
 from operator import itemgetter
-from ..compat import get_module_res
+from .._compat import get_module_res
 
-_get_module_path = lambda path: os.path.normpath(os.path.join(os.getcwd(),
-                                                 os.path.dirname(__file__), path))
 _get_abs_path = jieba._get_abs_path
 
-DEFAULT_IDF = _get_module_path("idf.txt")
+DEFAULT_IDF = "analyse/idf.txt"
 
 
 class KeywordExtractor(object):


### PR DESCRIPTION
在 Spark 中使用 jieba 分词时，要求包以 zip 的形式引入，analyse 模块没有按照 pkg_resource 的方式引用词典文件导致报错。

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "jieba/analyse/__init__.py", line 9, in <module>
    default_tfidf = TFIDF()
  File "jieba.zip/jieba/analyse/tfidf.py", line 69, in __init__
  File "jieba.zip/jieba/analyse/tfidf.py", line 42, in __init__
  File "jieba.zip/jieba/analyse/tfidf.py", line 51, in set_new_path
IOError: [Errno 20] Not a directory: '/home/xxx/jieba/jieba-0.39/jieba.zip/jieba/analyse/idf.txt'
```