### PR TITLE
fix the error about importing ChineseAnalyzer

### DIFF
--- a/test/test_whoosh.py
+++ b/test/test_whoosh.py
@@ -6,7 +6,7 @@ from whoosh.index import create_in,open_dir
 from whoosh.fields import *
 from whoosh.qparser import QueryParser
 
-from jieba.analyse import ChineseAnalyzer
+from jieba.analyse.analyzer import ChineseAnalyzer
 
 analyzer = ChineseAnalyzer()
 


### PR DESCRIPTION
Because of the interface change about ChineseAnlayzer , the code 'from jieba.analyse import Chinese Analyzer' in this test file would report an ImportError like 'cannot import name ChineseAnalyzer'. Changing import code to 'from jieba.analyse.analyzer import ChineseAnalyzer' can fix it.