### PR TITLE
fix the inconsistent segment result

### DIFF
--- a/jieba/posseg/__init__.py
+++ b/jieba/posseg/__init__.py
@@ -6,6 +6,7 @@ import jieba
 import pickle
 from .._compat import *
 from .viterbi import viterbi
+from .. import finalseg
 
 PROB_START_P = "prob_start.p"
 PROB_TRANS_P = "prob_trans.p"
@@ -136,8 +137,10 @@ class POSTokenizer(object):
         blocks = re_han_detail.split(sentence)
         for blk in blocks:
             if re_han_detail.match(blk):
-                for word in self.__cut(blk):
-                    yield word
+                recognized = finalseg.cut(blk)
+                for t in recognized:
+                    for word in self.__cut(t):
+                        yield word
             else:
                 tmp = re_skip_detail.split(blk)
                 for x in tmp:

--- a/jieba/posseg/viterbi.py
+++ b/jieba/posseg/viterbi.py
@@ -16,8 +16,13 @@ def viterbi(obs, states, start_p, trans_p, emit_p):
     mem_path = [{}]
     all_states = trans_p.keys()
     for y in states.get(obs[0], all_states):  # init
+        
+        if y[0] != 'B' and len(obs) > 1: continue
+        if y[0] != 'S' and len(obs) == 1: continue
+        
         V[0][y] = start_p[y] + emit_p[y].get(obs[0], MIN_FLOAT)
         mem_path[0][y] = ''
+        
     for t in xrange(1, len(obs)):
         V.append({})
         mem_path.append({})
@@ -27,9 +32,12 @@ def viterbi(obs, states, start_p, trans_p, emit_p):
 
         prev_states_expect_next = set(
             (y for x in prev_states for y in trans_p[x].keys()))
-        obs_states = set(
-            states.get(obs[t], all_states)) & prev_states_expect_next
-
+        
+        if t < len(obs) - 1: obs_states = [y for y in states.get(obs[t], all_states) if y[0] == 'M']
+        else: obs_states = [y for y in states.get(obs[t], all_states) if y[0] == 'E']
+        
+        obs_states = set(obs_states) & prev_states_expect_next
+        
         if not obs_states:
             obs_states = prev_states_expect_next if prev_states_expect_next else all_states
 


### PR DESCRIPTION
修正不一致的分詞結果

問題產生:
由於未知詞處理的HMM模型不同導致,
一般分詞和詞性標註分詞的結果有差異 (jieba.cut vs jieba.posseg.cut)

修正方法:
因此在進行詞性標註前,
先採用原先一般分詞的HMM模型
引入finalseg來進行處理未知詞
接著保持finalseg分詞後的標註 (B,M,E,S) 等信息
來viterbi算法中過濾不合適的states

範例代碼
```
import jieba
import jieba.posseg as pseg

seg_list = jieba.cut("他来到了网易杭研大厦")
print(", ".join(seg_list))

words = pseg.cut("他来到了网易杭研大厦")
for word, flag in words:
    print('%s %s' % (word, flag))
```

原先輸出
```
他, 来到, 了, 网易, 杭研, 大厦
他 r
来到 v
了 ul
网易 n
杭 j
研 vn
大厦 n
```

修正錯誤
```
他, 来到, 了, 网易, 杭研, 大厦
他 r
来到 v
了 ul
网易 n
杭研 nr
大厦 n
```

fix the inconsistent result between word segement (jieba.cut) and part-of-speech tagging (jieba.posseg.cut)
