### PR TITLE
Changing cache file rigths to 666 so that different users on the same…

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -152,6 +152,7 @@ class Tokenizer(object):
                         with os.fdopen(fd, 'wb') as temp_cache_file:
                             marshal.dump(
                                 (self.FREQ, self.total), temp_cache_file)
+                        os.chmod(fpath, 0o666)                    
                         _replace_file(fpath, cache_file)
                     except Exception:
                         default_logger.exception("Dump cache file failed.")


### PR DESCRIPTION
… machine could use it concurrently.

Otherwise, it fails at initialization and cache is not used so there are no initialization gains in the case of two different users running the library in the same machine.