### PR TITLE
Add only logging.NullHandler to default_logger

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 import logging
+from logging import NullHandler
 import marshal
 import tempfile
 import threading
@@ -25,10 +26,8 @@ _get_abs_path = lambda path: os.path.normpath(os.path.join(os.getcwd(), path))
 DEFAULT_DICT = None
 DEFAULT_DICT_NAME = "dict.txt"
 
-log_console = logging.StreamHandler(sys.stderr)
 default_logger = logging.getLogger(__name__)
-default_logger.setLevel(logging.DEBUG)
-default_logger.addHandler(log_console)
+default_logger.addHandler(NullHandler())
 
 DICT_WRITING = {}
 
@@ -111,7 +110,10 @@ class Tokenizer(object):
             if self.initialized:
                 return
 
-            default_logger.debug("Building prefix dict from %s ..." % (abs_path or 'the default dictionary'))
+            default_logger.debug(
+                "Building prefix dict from %s ..."
+                % (abs_path or 'the default dictionary')
+            )
             t1 = time.time()
             if self.cache_file:
                 cache_file = self.cache_file


### PR DESCRIPTION
This is a library, not an application, and it should be up to the end user, not the developer, what the log level and handler is.

Setting up the logger with a DEBUG level and sys.stderr handler is not a widely used practice in Python libraries.  The common practice is to add only NullHandler:

> An instance of this handler could be added to the top-level logger of the logging namespace used by the library (if you want to prevent your library’s logged events being output to sys.stderr in the absence of logging configuration).

See also:
https://docs.python-guide.org/writing/logging/#logging-in-a-library