### PR TITLE
sentence split exclude · many names include ·

### DIFF
--- a/jieba/__init__.py
+++ b/jieba/__init__.py
@@ -42,7 +42,7 @@ re_eng = re.compile('[a-zA-Z0-9]', re.U)
 # \r\n|\s : whitespace characters. Will not be handled.
 # re_han_default = re.compile("([\u4E00-\u9FD5a-zA-Z0-9+#&\._%]+)", re.U)
 # Adding "-" symbol in re_han_default
-re_han_default = re.compile("([\u4E00-\u9FD5a-zA-Z0-9+#&\._%\-]+)", re.U)
+re_han_default = re.compile("([\u4E00-\u9FD5a-zA-Z0-9+#&\.·_%\-]+)", re.U)
 
 re_skip_default = re.compile("(\r\n|\s)", re.U)
 re_han_cut_all = re.compile("([\u4E00-\u9FD5]+)", re.U)


### PR DESCRIPTION
在分词的时候，建议将“·”添加到re_han_default当中，因为好多人名是以该标点符号连接的，如果不添加，即使将带“·”的人名添加到词典中，也得不到正确解决，例如：
联系艾米·阿木汗的跆拳道老师克依拉·阿衣不拉