### PR TITLE
 add global declaration for start_P and trans_P (for improving symmetry, readability and syntax correctness)

### DIFF
--- a/jieba/finalseg/__init__.py
+++ b/jieba/finalseg/__init__.py
@@ -57,7 +57,7 @@ def viterbi(obs, states, start_p, trans_p, emit_p):
 
 
 def __cut(sentence):
-    global emit_P
+    global emit_P, start_P, trans_P
     prob, pos_list = viterbi(sentence, 'BMES', start_P, trans_P, emit_P)
     begin, nexti = 0, 0
     # print pos_list, sentence


### PR DESCRIPTION
__cut函数中只有emit_P的global声明，提交的改动中添加了start_P和trans_P的global声明：为了提高语法正确性，代码对称性和可读性