### PR TITLE
Fix simple typo: vocabuary -> vocabulary

### DIFF
--- a/jieba/lac_small/reader_small.py
+++ b/jieba/lac_small/reader_small.py
@@ -64,7 +64,7 @@ class Dataset(object):
     
     @property
     def vocab_size(self):
-        """vocabuary size"""
+        """vocabulary size"""
         return max(self.word2id_dict.values()) + 1
     
     @property


### PR DESCRIPTION
Closes #796

