### PR TITLE
Remove meaningless branch statements

### DIFF
--- a/jieba/analyse/tfidf.py
+++ b/jieba/analyse/tfidf.py
@@ -110,7 +110,5 @@ class TFIDF(KeywordExtractor):
             tags = sorted(freq.items(), key=itemgetter(1), reverse=True)
         else:
             tags = sorted(freq, key=freq.__getitem__, reverse=True)
-        if topK:
-            return tags[:topK]
-        else:
-            return tags
+
+        return tags[:topK]


### PR DESCRIPTION
There always have the variable 'topK'. 'tags[:topK] can be returned
 directly.